### PR TITLE
Update soliloquio-del-solteron.md

### DIFF
--- a/roberto-arlt/aguafuertes-portenas/soliloquio-del-solteron.md
+++ b/roberto-arlt/aguafuertes-portenas/soliloquio-del-solteron.md
@@ -42,7 +42,7 @@ Hay días que me despierto con un sentimiento de dulzura florecien­do en mi cor
 
 Si estoy de buen humor, compro un diario y me entero de lo que pasa en el mundo, y siempre me convenzo de que es inútil que pro­grese la ciencia de los hombres si continúan manteniendo duro y agrio su corazón como era el corazón de los seres humanos hace mil años.
 
-Al anochecer vuelvo a mi cuartujo de cenobita, y mientras espero que la sirvienta -una chica muy bruta y muy irritable- ponga la mesa, "sotto voce" canturreo Una furtiva lágrima, o sino Addio del passato o Bei giorni ridenti... Y mi corazón se anega de una paz maravillosa, y no me arrepiento de haber nacido.
+Al anochecer vuelvo a mi cuartujo de cenobita, y mientras espero que la sirvienta -una chica muy bruta y muy irritable- ponga la mesa, "sotto voce" canturreo Una furtiva lágrima, o sino Addio, del passato bei sogni ridenti... Y mi corazón se anega de una paz maravillosa, y no me arrepiento de haber nacido.
 
 No tengo parientes, y como respeto la belleza y detesto la des­composición, me he inscripto en la sociedad de cremaciones para que el día que yo muera el fuego me consuma y quede de mí, como úni­co rastro de mi limpio paso sobre la tierra, unas puras cenizas.
 


### PR DESCRIPTION
Me parece que "Addio del passato o Bei giorni ridenti" es un error tipografico: Arlt se refiere al aria titulada _Addio del passato_ de _La Traviata_ de Verdi, en donde un verso es:

> Addio, del passato bei sogni ridenti

Ver:
http://opera.stanford.edu/iu/libretti/traviata.html
https://www.youtube.com/watch?v=5voIiukYfKU

Noten que mi edición (Terramar 2013) tiene el mismo error.